### PR TITLE
Refactor provider initialization

### DIFF
--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -1,8 +1,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
 import { Toaster } from 'sonner';
 
-export const Providers = ({ children }: { children: React.ReactNode }) => {
-  const queryClient = new QueryClient();
+export const Providers: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [queryClient] = React.useState(() => new QueryClient());
   return (
     <QueryClientProvider client={queryClient}>
       {children}

--- a/src/lib/utils/common.ts
+++ b/src/lib/utils/common.ts
@@ -14,11 +14,7 @@ export const DATE_TIME_IN_UTC = "yyyy.MM.dd, HH:mm '(UTC)'";
 export const FULL_DATE_TIME = 'HH:mm:ss, dd/MM/yyyy';
 export const UTC_TIME_HUMANIZE = "HH:mm '(UTC)' LLLL dd yyyy";
 
-export async function sleep(time: number) {
-  return await new Promise((resolve) => {
-    setTimeout(resolve, time);
-  });
-}
+export const sleep = (time: number) => new Promise<void>((resolve) => setTimeout(resolve, time));
 
 export const formatTime = (time: DateTime | undefined, format = DATE_TIME_IN_UTC) => {
   return time?.toFormat(format) ?? 'N/A';


### PR DESCRIPTION
## Summary
- ensure `QueryClient` is only created once in `Providers`
- simplify `sleep` helper

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d2dd9d38883309e77483aee022dfb